### PR TITLE
fix: New packages are not added into `demo`

### DIFF
--- a/packages/plugin-tools/src/generators/sync-packages-with-demos/index.ts
+++ b/packages/plugin-tools/src/generators/sync-packages-with-demos/index.ts
@@ -67,7 +67,7 @@ function addToDemoIndex(tree: Tree, type: SupportedDemoType, demoAppRoot: string
     resetAngularIndex(tree, getPackageNamesToUpdate(), true);
     resetAngularRoutes(tree, getPackageNamesToUpdate(), true);
     return tree;
-  } else if (['react', 'svelte', 'vue']) {
+  } else if (['react', 'svelte', 'vue'].includes(type)) {
     // TODO: add index page for these flavors
     return tree;
   }


### PR DESCRIPTION
This fixes plain NativeScript demo list not being updated with new packages in plugin-seed.