### PR TITLE
fix: remove-package from demo flavours used

### DIFF
--- a/packages/plugin-tools/src/generators/remove-package/index.ts
+++ b/packages/plugin-tools/src/generators/remove-package/index.ts
@@ -22,9 +22,11 @@ export default function (tree: Tree, schema: Schema) {
   
     for (const t of getDemoTypes()) {
       const demoAppRoot = getDemoAppRoot(t);
-      removeDemoFiles(tree, t, demoAppRoot);
-      removeFromDemoIndex(tree, t, demoAppRoot);
-      updateDemoDependencies(tree, t, demoAppRoot);
+      if (tree.exists(demoAppRoot)) { 
+        removeDemoFiles(tree, t, demoAppRoot);
+        removeFromDemoIndex(tree, t, demoAppRoot);
+        updateDemoDependencies(tree, t, demoAppRoot);
+      }
     }
   
     removeSharedDemoFiles(tree);


### PR DESCRIPTION
Only delete the specific package from demo flavours used rather than
depend on a package.json being present.

Closes: #8